### PR TITLE
Basic build tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ It accepts the following flags:
 		given pattern as a prefix (see below for the default).
 	-n
 		Don't make any changes; just perform checks.
-	-tags "tag_name1 tag_name2"
-		Use tag_name[1|2] as a set of build tags that can have its packages
-		rewritten.
+	-tags 'tag list'
+		A space-separated list of build tags to satisfy when considering
+		files to change.
 
 If the pattern is not specified with the -m flag, it is derived from
 new-package-path and matches any prefix that is the same in all but

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ It accepts the following flags:
 		given pattern as a prefix (see below for the default).
 	-n
 		Don't make any changes; just perform checks.
-	-tag tag_name
-		Use tag_name as a build tag that can have its packages
+	-tags "tag_name1 tag_name2"
+		Use tag_name[1|2] as a set of build tags that can have its packages
 		rewritten.
 
 If the pattern is not specified with the -m flag, it is derived from

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It prints the names of any packages that are modified.
 
 Usage:
 
-	govers [-d] [-m regexp] [-n] new-package-path
+	govers [-d] [-m regexp] [tag tag_name] [-n] new-package-path
 
 It accepts the following flags:
 
@@ -17,6 +17,9 @@ It accepts the following flags:
 		given pattern as a prefix (see below for the default).
 	-n
 		Don't make any changes; just perform checks.
+	-tag tag_name
+		Use tag_name as a build tag that can have its packages
+		rewritten.
 
 If the pattern is not specified with the -m flag, it is derived from
 new-package-path and matches any prefix that is the same in all but

--- a/govers.go
+++ b/govers.go
@@ -18,6 +18,9 @@ It accepts the following flags:
 		given pattern as a prefix (see below for the default).
 	-n
 		Don't make any changes; just perform checks.
+	-tags 'tag list'
+		A space-separated list of build tags to satisfy when considering
+		files to change.
 
 If the pattern is not specified with the -m flag, it is derived from
 new-package-path and matches any prefix that is the same in all but
@@ -59,8 +62,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-
-	"golang.org/x/tools/go/buildutil"
 )
 
 const help = `
@@ -83,9 +84,9 @@ It accepts the following flags:
 		given pattern as a prefix (see below for the default).
 	-n
 		Don't make any changes; just perform checks.
-	-tags "tag_name1 tag_name2"
-		Use tag_name[1|2] as a build tag that can have its packages
-		rewritten.
+	-tags 'tag list'
+		A space-separated list of build tags to satisfy when considering
+		files to change.
 
 If the pattern is not specified with the -m flag, it is derived from
 new-package-path and matches any prefix that is the same in all but
@@ -118,7 +119,7 @@ var (
 var cwd, _ = os.Getwd()
 
 func init() {
-	flag.Var((*buildutil.TagsFlag)(&build.Default.BuildTags), "tags", buildutil.TagsFlagDoc)
+	flag.Var((*tagsFlag)(&build.Default.BuildTags), "tags", "a space-separated list of build tags to satisfy when considering files to change")
 }
 
 func main() {

--- a/govers.go
+++ b/govers.go
@@ -59,6 +59,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"golang.org/x/tools/go/buildutil"
 )
 
 const help = `
@@ -81,8 +83,8 @@ It accepts the following flags:
 		given pattern as a prefix (see below for the default).
 	-n
 		Don't make any changes; just perform checks.
-	-tag tag_name
-		Use tag_name as a build tag that can have its packages
+	-tags "tag_name1 tag_name2"
+		Use tag_name[1|2] as a build tag that can have its packages
 		rewritten.
 
 If the pattern is not specified with the -m flag, it is derived from
@@ -111,10 +113,13 @@ var (
 	match          = flag.String("m", "", "change imports with a matching prefix")
 	noEdit         = flag.Bool("n", false, "don't make any changes; perform checks only")
 	noDependencies = flag.Bool("d", false, "suppress dependency checking")
-	tag            = flag.String("tag", "", "specify a build flag to rewrite paths for (default no build flags)")
 )
 
 var cwd, _ = os.Getwd()
+
+func init() {
+	flag.Var((*buildutil.TagsFlag)(&build.Default.BuildTags), "tags", buildutil.TagsFlagDoc)
+}
 
 func main() {
 	flag.Usage = func() {
@@ -145,7 +150,6 @@ func main() {
 	// The solution is to avoid using build.Import but it's convenient
 	// at the moment.
 	// buildCtxt.UseAllFiles = true
-	buildCtxt.BuildTags = []string{*tag}
 	ctxt := &context{
 		cwd:           cwd,
 		newPackage:    newPackage,

--- a/govers.go
+++ b/govers.go
@@ -70,7 +70,7 @@ It prints the names of any packages that are modified.
 
 Usage:
 
-	govers [-d] [-m regexp] [-n] new-package-path
+	govers [-d] [-m regexp] [tag tag_name] [-n] new-package-path
 
 It accepts the following flags:
 
@@ -81,6 +81,9 @@ It accepts the following flags:
 		given pattern as a prefix (see below for the default).
 	-n
 		Don't make any changes; just perform checks.
+	-tag tag_name
+		Use tag_name as a build tag that can have its packages
+		rewritten.
 
 If the pattern is not specified with the -m flag, it is derived from
 new-package-path and matches any prefix that is the same in all but
@@ -108,6 +111,7 @@ var (
 	match          = flag.String("m", "", "change imports with a matching prefix")
 	noEdit         = flag.Bool("n", false, "don't make any changes; perform checks only")
 	noDependencies = flag.Bool("d", false, "suppress dependency checking")
+	tag            = flag.String("tag", "", "specify a build flag to rewrite paths for (default no build flags)")
 )
 
 var cwd, _ = os.Getwd()
@@ -140,7 +144,8 @@ func main() {
 	// if we don't set this flag, but if we do set it, the import fails.
 	// The solution is to avoid using build.Import but it's convenient
 	// at the moment.
-	//	buildCtxt.UseAllFiles = true
+	// buildCtxt.UseAllFiles = true
+	buildCtxt.BuildTags = []string{*tag}
 	ctxt := &context{
 		cwd:           cwd,
 		newPackage:    newPackage,

--- a/govers.go
+++ b/govers.go
@@ -119,7 +119,7 @@ var (
 var cwd, _ = os.Getwd()
 
 func init() {
-	flag.Var((*tagsFlag)(&build.Default.BuildTags), "tags", "a space-separated list of build tags to satisfy when considering files to change")
+	flag.Var((*TagsFlag)(&build.Default.BuildTags), "tags", "a space-separated list of build tags to satisfy when considering files to change")
 }
 
 func main() {

--- a/tags.go
+++ b/tags.go
@@ -4,9 +4,9 @@ package main
 
 import "fmt"
 
-type tagsFlag []string
+type TagsFlag []string
 
-func (v *tagsFlag) Set(s string) error {
+func (v *TagsFlag) Set(s string) error {
 	var err error
 	*v, err = splitQuotedFields(s)
 	if *v == nil {
@@ -15,7 +15,7 @@ func (v *tagsFlag) Set(s string) error {
 	return err
 }
 
-func (v *tagsFlag) Get() interface{} { return *v }
+func (v *TagsFlag) Get() interface{} { return *v }
 
 func splitQuotedFields(s string) ([]string, error) {
 	// Split fields allowing '' or "" around elements.
@@ -53,7 +53,7 @@ func splitQuotedFields(s string) ([]string, error) {
 	return f, nil
 }
 
-func (v *tagsFlag) String() string {
+func (v *TagsFlag) String() string {
 	return "<tagsFlag>"
 }
 

--- a/tags.go
+++ b/tags.go
@@ -1,0 +1,62 @@
+package main
+
+// This logic was copied from golang.org/x/tools/go/buildutil/tags.go to remove an external dependency
+
+import "fmt"
+
+type tagsFlag []string
+
+func (v *tagsFlag) Set(s string) error {
+	var err error
+	*v, err = splitQuotedFields(s)
+	if *v == nil {
+		*v = []string{}
+	}
+	return err
+}
+
+func (v *tagsFlag) Get() interface{} { return *v }
+
+func splitQuotedFields(s string) ([]string, error) {
+	// Split fields allowing '' or "" around elements.
+	// Quotes further inside the string do not count.
+	var f []string
+	for len(s) > 0 {
+		for len(s) > 0 && isSpaceByte(s[0]) {
+			s = s[1:]
+		}
+		if len(s) == 0 {
+			break
+		}
+		// Accepted quoted string. No unescaping inside.
+		if s[0] == '"' || s[0] == '\'' {
+			quote := s[0]
+			s = s[1:]
+			i := 0
+			for i < len(s) && s[i] != quote {
+				i++
+			}
+			if i >= len(s) {
+				return nil, fmt.Errorf("unterminated %c string", quote)
+			}
+			f = append(f, s[:i])
+			s = s[i+1:]
+			continue
+		}
+		i := 0
+		for i < len(s) && !isSpaceByte(s[i]) {
+			i++
+		}
+		f = append(f, s[:i])
+		s = s[i:]
+	}
+	return f, nil
+}
+
+func (v *tagsFlag) String() string {
+	return "<tagsFlag>"
+}
+
+func isSpaceByte(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}


### PR DESCRIPTION
Hi! This tool is great!

However I really needed to support easily and painlessly moving some imports inside build tagged files as well. I would ideally like to be able to specify any number of build tags and govers will rewrite the imports for anything without build tags or any of the build tags listed. However to do so would require using a more sophisticated flag parsing framework (I like [go-flags](https://github.com/jessevdk/go-flags)). For now I decided to stick to a lower impact change that supports providing a single build tag if you want it.

